### PR TITLE
refactor: replace FasterCSV with stdlib CSV

### DIFF
--- a/lib/tiny_ci/output.rb
+++ b/lib/tiny_ci/output.rb
@@ -1,19 +1,21 @@
+require "csv"
+
 module TinyCI
   class Output
     include Enumerable
-    
+
     class OutputLine
       attr_accessor :timestamp, :command, :line
-      
+
       def initialize(timestamp, command, line)
         @timestamp, @command, @line = Time.at(timestamp.to_f), command, line
       end
     end
-    
+
     def initialize(output_string_or_array)
       if output_string_or_array.is_a?(String)
         @output = []
-        FasterCSV.parse(output_string_or_array || "") { |timestamp, command, line| @output << OutputLine.new(timestamp, command, line) }
+        CSV.parse(output_string_or_array || "") { |timestamp, command, line| @output << OutputLine.new(timestamp, command, line) }
       else
         @output = output_string_or_array
       end


### PR DESCRIPTION
## Summary
- Replace `FasterCSV.parse` with stdlib `CSV.parse` in `lib/tiny_ci/output.rb` (the `fastercsv` gem was merged into Ruby's stdlib as `CSV` in 1.9.2 and is no longer in the Gemfile).
- Add an explicit `require "csv"` at the top of the file so it loads cleanly under Zeitwerk regardless of which other models/files have already pulled in `csv`.
- `app/models/build.rb` already does `require "csv"` for the `Array#to_csv` call on the build-output line, so no change needed there. Searched the worktree (excluding `Gemfile.lock` and `vendor/`) for any other `FasterCSV`/`fastercsv` usages — only docs (`CLAUDE.md`, `docs/modernize.md`) reference the legacy name, which is expected.

## Validation
- `bundle install` — clean.
- `bin/rails zeitwerk:check` — "All is good!" (eager loaded with no errors).

Closes #13

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>