### PR TITLE
fix: Localhost shell success? compares Process::Status to Integer

### DIFF
--- a/lib/tiny_ci/shell/localhost.rb
+++ b/lib/tiny_ci/shell/localhost.rb
@@ -44,7 +44,7 @@ module TinyCI
       
     private
       def success?
-        $? == 0
+        $?.success?
       end
       
       def build_environment(environment = {})


### PR DESCRIPTION
## Summary

- `Shell::Localhost#success?` did `$? == 0`, which is always false because `$?` is a `Process::Status` object, not an Integer — every locally-run command was treated as failed.
- Replaced with `$?.success?`, the idiomatic form that also handles signal-terminated processes correctly.

Closes #27

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>