### PR TITLE
refactor: replace RAILS_ROOT with Rails.root

### DIFF
--- a/app/helpers/builds_helper.rb
+++ b/app/helpers/builds_helper.rb
@@ -1,6 +1,6 @@
 module BuildsHelper
   def render_report(report, version)
-    template_path = "#{RAILS_ROOT}/lib/tiny_ci/report/templates/#{version}/#{report.class.name.underscore.split('/').last}.html.erb"
+    template_path = Rails.root.join('lib', 'tiny_ci', 'report', 'templates', version.to_s, "#{report.class.name.underscore.split('/').last}.html.erb").to_s
     begin
       render :file => template_path, :locals => { :report => report }
     rescue ActionView::MissingTemplate

--- a/app/views/admin/setup/_config_info.de.html.erb
+++ b/app/views/admin/setup/_config_info.de.html.erb
@@ -8,8 +8,8 @@
 </p>
 
 <ul class="asterisk">
-  <li>die <code>.yml</code>-Dateien in <code><%= RAILS_ROOT %>/config/</code> bearbeiten und TinyCI neu starten, oder</li>
-  <li>alle <code>.yml</code>-Dateien in <code><%= RAILS_ROOT %>/config/</code> löschen und TinyCI neu starten, um erneut auf diese Seite zu gelangen.</li>
+  <li>die <code>.yml</code>-Dateien in <code><%= Rails.root %>/config/</code> bearbeiten und TinyCI neu starten, oder</li>
+  <li>alle <code>.yml</code>-Dateien in <code><%= Rails.root %>/config/</code> löschen und TinyCI neu starten, um erneut auf diese Seite zu gelangen.</li>
 </ul>
 
 <p><strong>ACHTUNG</strong> Falls Sie die Datenbankkonfiguration später ändern (z.B. den Datenbanknamen), können Sie möglicherweise nicht mehr auf Ihre Daten zugreifen.</p>

--- a/app/views/admin/setup/_config_info.html.erb
+++ b/app/views/admin/setup/_config_info.html.erb
@@ -8,8 +8,8 @@
 </p>
 
 <ul class="asterisk">
-  <li>edit the <code>.yml</code> files in <code><%= RAILS_ROOT %>/config/</code> and restart TinyCI, or</li>
-  <li>remove all <code>.yml</code> files in <code><%= RAILS_ROOT %>/config/</code> and restart TinyCI to get this setup wizard again.</li>
+  <li>edit the <code>.yml</code> files in <code><%= Rails.root %>/config/</code> and restart TinyCI, or</li>
+  <li>remove all <code>.yml</code> files in <code><%= Rails.root %>/config/</code> and restart TinyCI to get this setup wizard again.</li>
 </ul>
 
 <p><strong>ATTENTION</strong> If you change the database configuration later on (for example the database name), your data may not be accessible anymore.</p>

--- a/app/views/admin/setup/index.html.erb
+++ b/app/views/admin/setup/index.html.erb
@@ -19,7 +19,7 @@
 
   <p class="form_item">
     <span class="label"><%= f.label :db_password, t('.database_password') %></span>
-    <span class="desc"><%= t('.password_description', :path => "<code>#{RAILS_ROOT}/config/database.yml</code>") %></span>
+    <span class="desc"><%= t('.password_description', :path => "<code>#{Rails.root}/config/database.yml</code>") %></span>
     <%= f.password_field :db_password %>
   </p>
   

--- a/config/options.yml
+++ b/config/options.yml
@@ -6,7 +6,7 @@
       en: "The language to be used by TinyCI."
       de: "Die Sprache, die von TinyCI benutzt wird."
     type: String
-    default: <%= YAML.load(File.read("#{RAILS_ROOT}/config/language.yml"))['language'] rescue 'en' %>
+    default: <%= YAML.load(File.read(Rails.root.join('config', 'language.yml').to_s))['language'] rescue 'en' %>
     values:
       - en
       - de

--- a/lib/tiny_ci/base_config.rb
+++ b/lib/tiny_ci/base_config.rb
@@ -66,9 +66,9 @@ module TinyCI
   private
     def config_file_name
       if @user_id
-        "#{RAILS_ROOT}/config/user_options.yml"
+        Rails.root.join('config', 'user_options.yml').to_s
       else
-        "#{RAILS_ROOT}/config/options.yml"
+        Rails.root.join('config', 'options.yml').to_s
       end
     end
   

--- a/lib/tiny_ci/setup/initial_config.rb
+++ b/lib/tiny_ci/setup/initial_config.rb
@@ -53,9 +53,9 @@ module TinyCI
       end
   
       def write_config
-        Dir.glob("#{RAILS_ROOT}/config/templates/*.yml.erb").each do |file_path|
+        Dir.glob(Rails.root.join('config', 'templates', '*.yml.erb').to_s).each do |file_path|
           file_name = File.basename(file_path).gsub(/\.erb$/, '')
-          File.open("#{RAILS_ROOT}/config/#{file_name}", 'w') do |file|
+          File.open(Rails.root.join('config', file_name).to_s, 'w') do |file|
             config = self
             file.print ERB.new(File.read(file_path)).result(binding)
           end

--- a/test/functional/lib/tiny_ci/shell/localhost_test.rb
+++ b/test/functional/lib/tiny_ci/shell/localhost_test.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/../../../../test_helper'
 class TinyCI::Shell::LocalhostTest < ActiveSupport::TestCase
   test "should find directory with exists?" do
     localhost = TinyCI::Shell::Localhost.new(Build.new)
-    assert localhost.exists?(File.dirname(__FILE__), RAILS_ROOT)
+    assert localhost.exists?(File.dirname(__FILE__), Rails.root.to_s)
   end
 
   test "should find file with exists?" do


### PR DESCRIPTION
## Summary

- Replaced the deprecated `RAILS_ROOT` constant (removed in Rails 3.0) with `Rails.root` across `lib/`, `app/helpers/`, `app/views/admin/setup/`, `config/options.yml`, and one test file.
- Used `Rails.root.join(...).to_s` where path concatenation reads naturally; kept simple `"#{Rails.root}/..."` interpolation in ERB views to match local style.
- The descriptive mention in `CLAUDE.md` (legacy Rails 2.3 patterns list) was left alone.

Closes #38

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>